### PR TITLE
String-Similarity-Commands - Added string similarity check on the com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ To respond when the user says a particular phrase, you can pass in a list of com
 - `command`: This is a string or `RegExp` representing the phrase you want to listen for
 - `callback`: The function that is executed when the command is spoken
 - `matchInterim`: Boolean that determines whether "interim" results should be matched against the command. This will make your component respond faster to commands, but also makes false positives more likely - i.e. the command may be detected when it is not spoken. This is `false` by default and should only be set for simple commands.
+- `isFuzzyMatch`: Boolean that determines whether the spoken phrase should be fuzzy matched against the `command`. This will let you know the similarity ratio between the phrase spoken by the user and the `command`. Fuzzy matching is intended to work only for commands that are string literals without special characters. If the `command` is a string with special characters or a `RegExp` it will be converted to a string without special characters at all. You could use this for phrases that are expected to be spoken by the user but are potentially easy to mispronounce or be misinterpreted by the Speech Recognition engine (e.g. names of places, sport teams, restaurant menu items). This is `false` by default.
+- `fuzzyMatchingThreshold`: This is a number ratio. If this number is smaller than the fuzzy matching similarity ratio the `callback` will be invoked. You should set this only if `isFuzzyMatch` is `true`. It takes values between `0` and `1`. The default value is `0.8`.
 
 ### Command symbols
 
@@ -177,6 +179,13 @@ const Dictaphone = () => {
       command: 'Hello',
       callback: () => setMessage('Hi there!'),
       matchInterim: true
+    },
+    {
+      command: 'Beijing',
+      callback: (command, spokenPhrase, similarityRatio) => setMessage(`${command} and ${spokenPhrase} are ${similarityRatio * 100}% similar`),
+      // If the spokenPhrase is Benji, the message would be ' Beijing and Benji are 40% similar
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 0.2
     }
   ]
 

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -697,3 +697,178 @@ describe('SpeechRecognition', () => {
     expect(hook1.result.current.finalTranscript).toEqual(speech)
   })
 })
+
+test('does not call command callback when isFuzzyMatch is not true', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: 'hello world',
+      callback: mockCommandCallback
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'This is a test'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(0)
+})
+
+test('does not call command callback when isFuzzyMatch is true and similarity is less than fuzzyMatchingThreshold', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: 'hello world',
+      callback: mockCommandCallback,
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 0.7
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'Hello'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(0)
+})
+
+test('does call command callback when isFuzzyMatch is true and similarity is equal or greater than fuzzyMatchingThreshold', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: 'hello world',
+      callback: mockCommandCallback,
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 0.5
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'Hello'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(1)
+})
+
+test('callback is called with command, transcript and similarity ratio between those', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: 'I want to eat',
+      callback: mockCommandCallback,
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 0.5
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'I want to drink'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(1)
+  expect(mockCommandCallback).toBeCalledWith('I want to eat', 'I want to drink', 0.6)
+})
+
+test('different callbacks can be called for the same speech and with fuzzyMatchingThreshold', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback1 = jest.fn()
+  const mockCommandCallback2 = jest.fn()
+  const commands = [
+    {
+      command: 'I want to eat',
+      callback: mockCommandCallback1,
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 1
+    },
+    {
+      command: 'I want to sleep',
+      callback: mockCommandCallback2,
+      isFuzzyMatch: true,
+      fuzzyMatchingThreshold: 0.2
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'I want to eat'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback1.mock.calls.length).toBe(1)
+  expect(mockCommandCallback2.mock.calls.length).toBe(1)
+})
+
+test('when command is regex with fuzzy match true runs similarity check with regex converted to string', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: new RegExp('This is a \\s+ test\\.+'),
+      callback: mockCommandCallback,
+      isFuzzyMatch: true
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'This is a test'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(1)
+  expect(mockCommandCallback).toBeCalledWith('This is a s test', 'This is a test', 0.8571428571428571)
+})
+
+test('when command is string special characters with fuzzy match true, special characters are removed from string and then we test similarity', async () => {
+  mockRecognitionManager()
+  const mockCommandCallback = jest.fn()
+  const commands = [
+    {
+      command: '! (I would :like) : * a :pizza ',
+      callback: mockCommandCallback,
+      isFuzzyMatch: true
+    }
+  ]
+  renderHook(() => useSpeechRecognition({ commands }))
+  const speech = 'I would like a pizza'
+
+  await act(async () => {
+    await SpeechRecognition.startListening()
+  })
+  act(() => {
+    SpeechRecognition.getRecognition().say(speech)
+  })
+
+  expect(mockCommandCallback.mock.calls.length).toBe(1)
+  expect(mockCommandCallback).toBeCalledWith('I would like a pizza', 'I would like a pizza', 1)
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,4 +39,37 @@ const commandToRegExp = (command) => {
   return new RegExp('^' + command + '$', 'i')
 }
 
-export { debounce, concatTranscripts, commandToRegExp }
+// this is from https://github.com/aceakash/string-similarity
+const compareTwoStringsUsingDiceCoefficient = (first, second) => {
+  first = first.replace(/\s+/g, '').toLowerCase()
+  second = second.replace(/\s+/g, '').toLowerCase()
+
+  if (!first.length && !second.length) return 1 // if both are empty strings
+  if (!first.length || !second.length) return 0 // if only one is empty string
+  if (first === second) return 1 // identical
+  if (first.length === 1 && second.length === 1) return 0 // both are 1-letter strings
+  if (first.length < 2 || second.length < 2) return 0 // if either is a 1-letter string
+
+  const firstBigrams = new Map()
+  for (let i = 0; i < first.length - 1; i++) {
+    const bigram = first.substring(i, i + 2)
+    const count = firstBigrams.has(bigram) ? firstBigrams.get(bigram) + 1 : 1
+
+    firstBigrams.set(bigram, count)
+  }
+
+  let intersectionSize = 0
+  for (let i = 0; i < second.length - 1; i++) {
+    const bigram = second.substring(i, i + 2)
+    const count = firstBigrams.has(bigram) ? firstBigrams.get(bigram) : 0
+
+    if (count > 0) {
+      firstBigrams.set(bigram, count - 1)
+      intersectionSize++
+    }
+  }
+
+  return (2.0 * intersectionSize) / (first.length + second.length - 2)
+}
+
+export { debounce, concatTranscripts, commandToRegExp, compareTwoStringsUsingDiceCoefficient }


### PR DESCRIPTION
…mands API

I implemented the fuzzy matching within the commands api as discussed in this [pull request](https://github.com/JamesBrill/react-speech-recognition/pull/46).

I wondered how to handle the cases where `isFuzzyMatch` is `true` but the api user passes a regex or a string with special characters as the command.
At first, for the 'string with special characters' case i thought that we should maybe do a fuzzy match check against the predefined or the variable part of the command but both seemed confusing for the user and probably not really helpful. Then i tried to decide the way that we will ignore these cases and i chose to convert **regex to string** and **string with special characters to string without them**. The other way to handle these would probably be to act like `isFuzzyMatch` is `false` for these cases but i decided against because the user has explicitly set it to `true`.

Is that what you had in mind? I am open, of course, for changes and proposals. 