### PR TITLE
Fix SSR support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {

--- a/src/isAndroid.js
+++ b/src/isAndroid.js
@@ -1,1 +1,3 @@
-export default () => /(android)/i.test(typeof navigator !== 'undefined' ? navigator.userAgent : "")
+const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+
+export default () => /(android)/i.test(userAgent)

--- a/src/isAndroid.js
+++ b/src/isAndroid.js
@@ -1,3 +1,1 @@
-const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : ''
-
-export default () => /(android)/i.test(userAgent)
+export default () => /(android)/i.test(typeof navigator !== 'undefined' ? navigator.userAgent : '')

--- a/src/isAndroid.test.js
+++ b/src/isAndroid.test.js
@@ -1,0 +1,32 @@
+import isAndroid from './isAndroid'
+
+const mockUserAgent = (userAgent) => {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, writable: true })
+}
+
+const mockUndefinedNavigator = () => {
+  Object.defineProperty(global, 'navigator', { value: undefined, writable: true })
+}
+
+describe('isAndroid', () => {
+  test('returns false when navigator.userAgent does not contain android string', () => {
+    mockUserAgent('safari browser')
+    const result = isAndroid()
+
+    expect(result).toEqual(false)
+  })
+
+  test('returns true when navigator.userAgent contains android string', () => {
+    mockUserAgent('android browser')
+    const result = isAndroid()
+
+    expect(result).toEqual(true)
+  })
+
+  test('returns false when navigator is undefined', () => {
+    mockUndefinedNavigator()
+    const result = isAndroid()
+
+    expect(result).toEqual(false)
+  })
+})


### PR DESCRIPTION
Adds fallback for server-side rendering when `navigator` is not defined. Is the release of https://github.com/JamesBrill/react-speech-recognition/pull/61