### PR TITLE
Make commands mutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer, useCallback } from 'react'
+import { useState, useEffect, useReducer, useCallback, useRef } from 'react'
 import { concatTranscripts, commandToRegExp, compareTwoStringsUsingDiceCoefficient } from './utils'
 import { clearTrancript, appendTrancript } from './actions'
 import { transcriptReducer } from './reducers'
@@ -15,6 +15,8 @@ const useSpeechRecognition = ({
     finalTranscript: ''
   })
   const [listening, setListening] = useState(recognitionManager.listening)
+  const commandsRef = useRef(commands)
+  commandsRef.current = commands
 
   const clearTranscript = () => {
     dispatch(clearTrancript())
@@ -27,7 +29,7 @@ const useSpeechRecognition = ({
 
   const matchCommands = useCallback(
     (newInterimTranscript, newFinalTranscript) => {
-      commands.forEach(({ command, callback, matchInterim = false, isFuzzyMatch = false, fuzzyMatchingThreshold = 0.8 }) => {
+      commandsRef.current.forEach(({ command, callback, matchInterim = false, isFuzzyMatch = false, fuzzyMatchingThreshold = 0.8 }) => {
         const input = !newFinalTranscript && matchInterim
           ? newInterimTranscript.trim()
           : newFinalTranscript.trim()
@@ -50,7 +52,7 @@ const useSpeechRecognition = ({
           }
         }
       })
-    }, [commands, resetTranscript]
+    }, [resetTranscript]
   )
 
   const handleTranscriptChange = useCallback(


### PR DESCRIPTION
Because the `commands` prop is an array, its value is always deemed to be changing when either (a) the default value is used or (b) the consumer does not memoize their `commands` value. The various callbacks and effects depending on `commands` get re-run on every change, including unrelated changes (e.g. transcript).

This was resulting in a race condition when multiple instances of `SpeechRecognition` were being rendered. While the transcript was being updated, the new transcripts would cause `commands` to "change" and re-run the dependent effects, including the one that subscribes and unsubscribes `SpeechRecognition` to `RecognitionManager`. As `RecognitionManager` updates its subscribers of transcript changes, they unsubscribe and resubscribe with a different ID. When having to iterate through many subscribers, the manager would sometimes find that a subscriber no longer existed due to unsubscribing with that old ID after a previous transcript change.

The solution is to stop subscribers from caring about changes to `commands`. `matchCommands`, the direct dependent of `commands`, now accesses it via a mutable ref, just getting whatever the latest value is.

I'm not sure how I feel about this - it feels like a misuse of hooks. Besides hashing `commands` and comparing that with its old value, this is the best I can come up with for now.