### PR TITLE
Async stopListening

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -207,7 +207,7 @@ Some known supported languages (based on [this Stack Overflow post](http://stack
 * Turkish `tr`
 * Zulu `zu`
 
-#### stopListening
+#### stopListening (async)
 
 Turn the microphone off, but still finish processing any speech in progress.
 
@@ -215,13 +215,17 @@ Turn the microphone off, but still finish processing any speech in progress.
 SpeechRecognition.stopListening()
 ```
 
-#### abortListening
+This is an asynchronous function, so it will need to be awaited if you want to do something after the microphone has been turned off.
+
+#### abortListening (async)
 
 Turn the microphone off, and cancel the processing of any speech in progress.
 
 ```
 SpeechRecognition.abortListening()
 ```
+
+This is an asynchronous function, so it will need to be awaited if you want to do something after the microphone has been turned off.
 
 #### browserSupportsSpeechRecognition
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -138,10 +138,7 @@ export default class RecognitionManager {
     const isLanguageChanged = language && language !== this.recognition.lang
     if (isContinuousChanged || isLanguageChanged) {
       if (this.listening) {
-        this.stopListening()
-        await new Promise(resolve => {
-          this.onStopListening = resolve
-        })
+        await this.stopListening()
       }
       this.recognition.continuous = isContinuousChanged ? continuous : this.recognition.continuous
       this.recognition.lang = isLanguageChanged ? language : this.recognition.lang
@@ -160,14 +157,20 @@ export default class RecognitionManager {
     }
   }
 
-  abortListening() {
+  async abortListening() {
     this.disconnect('ABORT')
     this.emitListeningChange(false)
+    await new Promise(resolve => {
+      this.onStopListening = resolve
+    })
   }
 
-  stopListening() {
+  async stopListening() {
     this.disconnect('STOP')
     this.emitListeningChange(false)
+    await new Promise(resolve => {
+      this.onStopListening = resolve
+    })
   }
 
   getRecognition() {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -120,13 +120,13 @@ const SpeechRecognition = {
     const recognitionManager = SpeechRecognition.getRecognitionManager()
     await recognitionManager.startListening({ continuous, language })
   },
-  stopListening: () => {
+  stopListening: async () => {
     const recognitionManager = SpeechRecognition.getRecognitionManager()
-    recognitionManager.stopListening()
+    await recognitionManager.stopListening()
   },
-  abortListening: () => {
+  abortListening: async () => {
     const recognitionManager = SpeechRecognition.getRecognitionManager()
-    recognitionManager.abortListening()
+    await recognitionManager.abortListening()
   },
   browserSupportsSpeechRecognition: () => {
     const recognitionManager = SpeechRecognition.getRecognitionManager()


### PR DESCRIPTION
`stopListening` and `abortListening` were previously synchronous functions, but the internal function for turning off the microphone is asynchronous. This made it impossible for consumers to wait for the microphone to be turned off. This PR addresses that, making these functions asynchronous and wait for the microphone to be turned off before returning.