### PR TITLE
Identify command that triggered callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
To enable consumers that provide an array of command phrases for the same command callback, the lib now passes in the matched command phrase back to the callback. This is passed in through the last argument as the `command` property. Example:
```
    {
      command: ['Hello', 'Hi'],
      callback: ({ command }) => setMessage(`Hi there! You said: "${command}"`),
      matchInterim: true
    }
```