### PR TITLE
Support polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This version requires React 16.8 so that React hooks can be used. If you're used
 
 * [Basic example](#basic-example)
 * [Supported browsers](#supported-browsers)
+* [Polyfills](docs/POLYFILLS.md)
 * [API docs](docs/API.md)
 * [Version 3 migration guide](docs/V3-MIGRATION.md)
 * [TypeScript declaration file in DefinitelyTyped](https://github.com/OleksandrYehorov/DefinitelyTyped/blob/master/types/react-speech-recognition/index.d.ts)
@@ -65,7 +66,7 @@ You can see more examples in the example React app attached to this repo. See [D
 
 ## Detecting browser support for Web Speech API
 
-Currently, this feature is not supported in all browsers, with the best experience being available on desktop Chrome. However, it fails gracefully on other browsers. It is recommended that you render some fallback content if it is not supported by the user's browser:
+Currently, this feature is not supported in all browsers (unless you integrate a [polyfill](docs/POLYFILLS.md)), with the best experience being available on desktop Chrome. However, it fails gracefully on other browsers. It is recommended that you render some fallback content if it is not supported by the user's browser:
 
 ```
 if (!SpeechRecognition.browserSupportsSpeechRecognition()) {
@@ -74,6 +75,8 @@ if (!SpeechRecognition.browserSupportsSpeechRecognition()) {
 ```
 
 ### Supported browsers
+
+The Web Speech API is largely only supported by Google browsers - if you want it to work on other browsers, this library does support polyfills to enable speech recognition outside of Chrome (see [here](docs/POLYFILLS.md) for more details).
 
 As of January 2021, the following browsers support the Web Speech API:
 
@@ -85,7 +88,7 @@ As of January 2021, the following browsers support the Web Speech API:
 
 iOS does not support the API on any browser.
 
-For all other browsers, you can render fallback content using the `SpeechRecognition.browserSupportsSpeechRecognition` function described above.
+For all other browsers, you can render fallback content using the `SpeechRecognition.browserSupportsSpeechRecognition` function described above. Alternatively, as mentioned before, you can integrate a [polyfill](docs/POLYFILLS.md).
 
 ## Controlling the microphone
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,6 +44,7 @@ These are returned from `useSpeechRecognition`:
     finalTranscript,
     resetTranscript,
     listening,
+    browserSupportsSpeechRecognition,
   } = useSpeechRecognition()
 ```
 
@@ -77,6 +78,18 @@ The difference between interim and final transcripts can be illustrated by an ex
 #### finalTranscript [string]
 
 Transcription of speech that the Web Speech API has finished processing.
+
+#### browserSupportsSpeechRecognition [bool]
+
+The Web Speech API is not supported on all browsers, so it is recommended that you render some fallback content if it is not supported by the user's browser:
+
+```
+if (!browserSupportsSpeechRecognition) {
+  // Render some fallback content
+}
+```
+
+It is recommended that you use this state to decide when to render fallback content rather than `SpeechRecognition.browserSupportsSpeechRecognition()` as this will correctly re-render your component if the browser support changes at run-time (e.g. due to a polyfill being applied).
 
 ## SpeechRecognition
 
@@ -237,6 +250,16 @@ if (!SpeechRecognition.browserSupportsSpeechRecognition()) {
 }
 ```
 
+It is recommended that you instead use the `browserSupportsSpeechRecognition` state from `useSpeechRecognition` to decide when to render fallback content - that will correctly re-render your component if the browser support changes at run-time (e.g. due to a polyfill being applied).
+
 #### getRecognition
 
 This returns the underlying [object](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition) used by Web Speech API.
+
+#### applyPolyfill
+
+Replace the default Speech Recognition engine (if there is one) with a custom implementation of the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). See [Polyfills](./POLYFILLS.md) for more information on how to use this.
+
+```
+SpeechRecognition.applyPolyfill(SpeechRecognitionPolyfill)
+```

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -15,8 +15,10 @@ SpeechRecognition.setSpeechRecognitionClient(SpeechRecognitionPolyfill)
 Note that this type of polyfill that does not pollute the global scope is known as a "ponyfill" - the distinction is explained [here](https://ponyfoo.com/articles/polyfills-or-ponyfills). `react-speech-recognition` will also pick up traditional polyfills - just make sure you import them before `react-speech-recognition`.
 
 ## Usage recommendations
-* Call this as early as possible, preferably before even calling `ReactDOM.render`
+* Call this as early as possible to minimise periods where fallback content, which you should render while the polyfill is loading, is rendered
+* Use your own `loadingSpeechRecognition` state rather than `browserSupportsSpeechRecognition` to decide when to render fallback content when Speech Recognition is not available. This is because on Chrome, `browserSupportsSpeechRecognition` will return `true` - as a result, your speech recognition component will appear briefly with the Google Speech Recognition engine and then with the polyfill engine, potentially causing a janky user experience. Some example code using the loading state approach can be found below
 * After `setSpeechRecognitionClient` has been called, `browserSupportsSpeechRecognition` will always be `true`. The polyfill itself may not work on all browsers - it's worth having a further fallback to cover that case. Polyfills will usually require WebRTC support in the browser, so it's worth checking that `window.navigator.mediaDevices.getUserMedia` is present
+* Do not rely on polyfills being perfect implementations of the Speech Recognition specification - make sure you have tested them in different browsers and are aware of their individual limitations
 
 # Polyfill libraries
 
@@ -35,7 +37,7 @@ This is Microsoft's offering for speech recognition (among many other features).
 Here is a basic example combining `web-speech-cognitive-services` and `react-speech-recognition` to get you started. This code worked with version 7.1.0 of the polyfill in February 2021 - if it has become outdated due to changes in the polyfill or in Azure Cognitive Services, please raise a GitHub issue or PR to get this updated.
 
 ```
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import createSpeechServicesPonyfill from 'web-speech-cognitive-services';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
@@ -43,32 +45,37 @@ const SUBSCRIPTION_KEY = '<INSERT_SUBSCRIPTION_KEY_HERE>';
 const REGION = '<INSERT_REGION_HERE>';
 const TOKEN_ENDPOINT = `https://${REGION}.api.cognitive.microsoft.com/sts/v1.0/issuetoken`;
 
-(async () => {
-  const response = await fetch(TOKEN_ENDPOINT, { 
-    method: 'POST', 
-    headers: { 'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY } 
-  });
-  const authorizationToken = await response.text();
-  const {
-    SpeechRecognition: AzureSpeechRecognition
-  } = await createSpeechServicesPonyfill({
-    credentials: {
-      region: REGION,
-      authorizationToken,
-    }
-  });
-  SpeechRecognition.setSpeechRecognitionClient(AzureSpeechRecognition);
-})();
-
 const Dictaphone = () => {
-  const { transcript, resetTranscript, browserSupportsSpeechRecognition } = useSpeechRecognition();
+  const [loadingSpeechRecognition, setLoadingSpeechRecognition] = useState(true);
+  const { transcript, resetTranscript } = useSpeechRecognition();
 
   const startListening = () => SpeechRecognition.startListening({
     continuous: true,
     language: 'en-US'
   });
 
-  if (!browserSupportsSpeechRecognition) {
+  useEffect(() => {
+    const loadSpeechRecognition = async () => {
+      const response = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY }
+      });
+      const authorizationToken = await response.text();
+      const {
+        SpeechRecognition: AzureSpeechRecognition
+      } = await createSpeechServicesPonyfill({
+        credentials: {
+          region: REGION,
+          authorizationToken,
+        }
+      });
+      SpeechRecognition.setSpeechRecognitionClient(AzureSpeechRecognition);
+      setLoadingSpeechRecognition(false);
+    }
+    loadSpeechRecognition();
+  }, []);
+
+  if (loadingSpeechRecognition) {
     return null;
   }
 
@@ -84,8 +91,6 @@ const Dictaphone = () => {
 export default Dictaphone;
 ```
 
-In the above example, the polyfill is asynchronously injected just before the component in defined. It's instead recommend that you perform this setup before your entire React app is rendered - i.e. before `ReactDOM.render` is called.
-
 ### Caveats
 * On Safari and Firefox, an error will be thrown if calling `startListening` with a different language without first calling `stopListening`. It's recommended that you stick to one langauge and, if you do need to change languages, call `stopListening` first. Works fine on Chrome
 * The default language will result in Azure returning a 400. You will need to explicitly define one of the language codes defined [here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). For English, use `en-GB` or `en-US`
@@ -98,7 +103,7 @@ There is no polyfill for this in the ecosystem yet, though a promising project c
 
 # Providing your own polyfill
 
-If you want to roll your own implementation of the Speech Recognition API, it should implement at least the following for `react-speech-recognition` to work:
+If you want to roll your own implementation of the Speech Recognition API, follow the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). You should implement at least the following for `react-speech-recognition` to work:
 * `continuous` (property)
 * `lang` (property)
 * `interimResults` (property)

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -37,7 +37,7 @@ This is Microsoft's offering for speech recognition (among many other features).
 Here is a basic example combining `web-speech-cognitive-services` and `react-speech-recognition` to get you started. This code worked with version 7.1.0 of the polyfill in February 2021 - if it has become outdated due to changes in the polyfill or in Azure Cognitive Services, please raise a GitHub issue or PR to get this updated.
 
 ```
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react';
 import createSpeechServicesPonyfill from 'web-speech-cognitive-services';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
@@ -87,7 +87,7 @@ const Dictaphone = () => {
       <p>{transcript}</p>
     </div>
   );
-}
+};
 export default Dictaphone;
 ```
 

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -1,0 +1,114 @@
+# Polyfills
+
+If you want `react-speech-recognition` to work on more browsers than just Chrome, you can integrate a polyfill. This is a piece of code that fills in some missing feature in browsers that don't support it.
+
+Under the hood, Web Speech API in Chrome uses Google's speech recognition servers. To replicate this functionality elsewhere, you will need to host your own speech recognition service and implement the Web Speech API using that service. That implementation, which is essentially a polyfill, can then be plugged into `react-speech-recognition`. You can write that polyfill yourself, but it's recommended you use one someone else has already made.
+
+# Basic usage
+
+The `SpeechRecognition` class exported by `react-speech-recognition` has the method `setSpeechRecognitionClient`. This can take an implementation of the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). From then on, that implementation will used by `react-speech-recognition` to transcribe speech picked up by the microphone.
+
+```
+SpeechRecognition.setSpeechRecognitionClient(SpeechRecognitionPolyfill)
+```
+
+Note that this type of polyfill that does not pollute the global scope is known as a "ponyfill" - the distinction is explained [here](https://ponyfoo.com/articles/polyfills-or-ponyfills). `react-speech-recognition` will also pick up traditional polyfills - just make sure you import them before `react-speech-recognition`.
+
+## Usage recommendations
+* Call this as early as possible, preferably before even calling `ReactDOM.render`
+* After `setSpeechRecognitionClient` has been called, `browserSupportsSpeechRecognition` will always be `true`. The polyfill itself may not work on all browsers - it's worth having a further fallback to cover that case. Polyfills will usually require WebRTC support in the browser, so it's worth checking that `window.navigator.mediaDevices.getUserMedia` is present
+
+# Polyfill libraries
+
+Rather than roll your own, you should use a ready-made polyfill for one of the major cloud providers' speech recognition services.
+
+## Azure Cognitive Services
+
+This is Microsoft's offering for speech recognition (among many other features). The free trial gives you $200 of credit to get started. It's pretty easy to set up - see the [documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/).
+
+* Polyfill repo: [web-speech-cognitive-services](https://github.com/compulim/web-speech-cognitive-services)
+* Polyfill author: [compulim](https://github.com/compulim)
+* Requirements:
+  * Install `web-speech-cognitive-services` and `microsoft-cognitiveservices-speech-sdk` in your web app for this polyfill to function
+  * You will need two things to configure this polyfill: the name of the Azure region your Speech Service is deployed in, plus a subscription key (or better still, an authorization token). [This doc](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/overview#find-keys-and-region) explains how to find those
+
+Here is a basic example combining `web-speech-cognitive-services` and `react-speech-recognition` to get you started. This code worked with version 7.1.0 of the polyfill in February 2021 - if it has become outdated due to changes in the polyfill or in Azure Cognitive Services, please raise a GitHub issue or PR to get this updated.
+
+```
+import React from 'react'
+import createSpeechServicesPonyfill from 'web-speech-cognitive-services';
+import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
+
+const SUBSCRIPTION_KEY = '<INSERT_SUBSCRIPTION_KEY_HERE>';
+const REGION = '<INSERT_REGION_HERE>';
+const TOKEN_ENDPOINT = `https://${REGION}.api.cognitive.microsoft.com/sts/v1.0/issuetoken`;
+
+(async () => {
+  const response = await fetch(TOKEN_ENDPOINT, { 
+    method: 'POST', 
+    headers: { 'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY } 
+  });
+  const authorizationToken = await response.text();
+  const {
+    SpeechRecognition: AzureSpeechRecognition
+  } = await createSpeechServicesPonyfill({
+    credentials: {
+      region: REGION,
+      authorizationToken,
+    }
+  });
+  SpeechRecognition.setSpeechRecognitionClient(AzureSpeechRecognition);
+})();
+
+const Dictaphone = () => {
+  const { transcript, resetTranscript, browserSupportsSpeechRecognition } = useSpeechRecognition();
+
+  const startListening = () => SpeechRecognition.startListening({
+    continuous: true,
+    language: 'en-US'
+  });
+
+  if (!browserSupportsSpeechRecognition) {
+    return null;
+  }
+
+  return (
+    <div>
+      <button onClick={startListening}>Start</button>
+      <button onClick={SpeechRecognition.stopListening}>Stop</button>
+      <button onClick={resetTranscript}>Reset</button>
+      <p>{transcript}</p>
+    </div>
+  );
+}
+export default Dictaphone;
+```
+
+In the above example, the polyfill is asynchronously injected just before the component in defined. It's instead recommend that you perform this setup before your entire React app is rendered - i.e. before `ReactDOM.render` is called.
+
+### Caveats
+* On Safari and Firefox, an error will be thrown if calling `startListening` with a different language without first calling `stopListening`. It's recommended that you stick to one langauge and, if you do need to change languages, call `stopListening` first. Works fine on Chrome
+* The default language will result in Azure returning a 400. You will need to explicitly define one of the language codes defined [here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). For English, use `en-GB` or `en-US`
+* Safari will throw an error on `localhost` as it requires HTTPS. [ngrok](https://ngrok.com/) is a nice tool for serving a local web app over HTTPS (also good for testing your web app on mobile devices as well).
+* Currently untested on iOS (let me know if it works!)
+
+## AWS Transcribe
+
+There is no polyfill for this in the ecosystem yet, though a promising project can be found [here](https://github.com/ceuk/speech-recognition-aws-polyfill).
+
+# Providing your own polyfill
+
+If you want to roll your own implementation of the Speech Recognition API, it should implement at least the following for `react-speech-recognition` to work:
+* `continuous` (property)
+* `lang` (property)
+* `interimResults` (property)
+* `onresult` (property). On the events received, the following properties are used:
+  * `event.resultIndex`
+  * `event.results[i].isFinal`
+  * `event.results[i][0].transcript`
+  * `event.results[i][0].confidence`
+* `onend` (property)
+* `start` (method)
+* `stop` (method)
+* `abort` (method)
+

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -6,10 +6,10 @@ Under the hood, Web Speech API in Chrome uses Google's speech recognition server
 
 # Basic usage
 
-The `SpeechRecognition` class exported by `react-speech-recognition` has the method `setSpeechRecognitionClient`. This can take an implementation of the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). From then on, that implementation will used by `react-speech-recognition` to transcribe speech picked up by the microphone.
+The `SpeechRecognition` class exported by `react-speech-recognition` has the method `applyPolyfill`. This can take an implementation of the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). From then on, that implementation will used by `react-speech-recognition` to transcribe speech picked up by the microphone.
 
 ```
-SpeechRecognition.setSpeechRecognitionClient(SpeechRecognitionPolyfill)
+SpeechRecognition.applyPolyfill(SpeechRecognitionPolyfill)
 ```
 
 Note that this type of polyfill that does not pollute the global scope is known as a "ponyfill" - the distinction is explained [here](https://ponyfoo.com/articles/polyfills-or-ponyfills). `react-speech-recognition` will also pick up traditional polyfills - just make sure you import them before `react-speech-recognition`.
@@ -17,7 +17,7 @@ Note that this type of polyfill that does not pollute the global scope is known 
 ## Usage recommendations
 * Call this as early as possible to minimise periods where fallback content, which you should render while the polyfill is loading, is rendered
 * Use your own `loadingSpeechRecognition` state rather than `browserSupportsSpeechRecognition` to decide when to render fallback content when Speech Recognition is not available. This is because on Chrome, `browserSupportsSpeechRecognition` will return `true` - as a result, your speech recognition component will appear briefly with the Google Speech Recognition engine and then with the polyfill engine, potentially causing a janky user experience. Some example code using the loading state approach can be found below
-* After `setSpeechRecognitionClient` has been called, `browserSupportsSpeechRecognition` will always be `true`. The polyfill itself may not work on all browsers - it's worth having a further fallback to cover that case. Polyfills will usually require WebRTC support in the browser, so it's worth checking that `window.navigator.mediaDevices.getUserMedia` is present
+* After `applyPolyfill` has been called, `browserSupportsSpeechRecognition` will always be `true`. The polyfill itself may not work on all browsers - it's worth having a further fallback to cover that case. Polyfills will usually require WebRTC support in the browser, so it's worth checking that `window.navigator.mediaDevices.getUserMedia` is present
 * Do not rely on polyfills being perfect implementations of the Speech Recognition specification - make sure you have tested them in different browsers and are aware of their individual limitations
 
 # Polyfill libraries
@@ -69,7 +69,7 @@ const Dictaphone = () => {
           authorizationToken,
         }
       });
-      SpeechRecognition.setSpeechRecognitionClient(AzureSpeechRecognition);
+      SpeechRecognition.applyPolyfill(AzureSpeechRecognition);
       setLoadingSpeechRecognition(false);
     }
     loadSpeechRecognition();

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -92,14 +92,14 @@ export default Dictaphone;
 ```
 
 ### Caveats
-* On Safari and Firefox, an error will be thrown if calling `startListening` with a different language without first calling `stopListening`. It's recommended that you stick to one langauge and, if you do need to change languages, call `stopListening` first. Works fine on Chrome
-* The default language will result in Azure returning a 400. You will need to explicitly define one of the language codes defined [here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). For English, use `en-GB` or `en-US`
-* Safari will throw an error on `localhost` as it requires HTTPS. [ngrok](https://ngrok.com/) is a nice tool for serving a local web app over HTTPS (also good for testing your web app on mobile devices as well).
+* On Safari and Firefox, an error will be thrown if calling `startListening` to switch to a different language without first calling `stopListening`. It's recommended that you stick to one language and, if you do need to change languages, call `stopListening` first
+* If you don't specify a language, Azure will return a 400 response. When calling `startListening`, you will need to explicitly provide one of the language codes defined [here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). For English, use `en-GB` or `en-US`
+* Safari will throw an error on `localhost` as it requires HTTPS. [ngrok](https://ngrok.com/) is a nice tool for serving a local web app over HTTPS (also good for testing your web app on mobile devices as well)
 * Currently untested on iOS (let me know if it works!)
 
 ## AWS Transcribe
 
-There is no polyfill for this in the ecosystem yet, though a promising project can be found [here](https://github.com/ceuk/speech-recognition-aws-polyfill).
+There is no polyfill for [AWS Transcribe](https://aws.amazon.com/transcribe/) in the ecosystem yet, though a promising project can be found [here](https://github.com/ceuk/speech-recognition-aws-polyfill).
 
 # Providing your own polyfill
 

--- a/example/src/Dictaphone/Dictaphone.js
+++ b/example/src/Dictaphone/Dictaphone.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import SpeechRecognition, { useSpeechRecognition } from '../SpeechRecognition'
+import { useSpeechRecognition } from '../SpeechRecognition'
 
 const Dictaphone = ({ commands }) => {
   const [transcribing, setTranscribing] = useState(true)
@@ -12,6 +12,7 @@ const Dictaphone = ({ commands }) => {
     finalTranscript,
     resetTranscript,
     listening,
+    browserSupportsSpeechRecognition
   } = useSpeechRecognition({ transcribing, clearTranscriptOnListen, commands })
   useEffect(() => {
     if (interimTranscript !== '') {
@@ -22,8 +23,8 @@ const Dictaphone = ({ commands }) => {
     }
   }, [interimTranscript, finalTranscript]);
 
-  if (!SpeechRecognition.browserSupportsSpeechRecognition()) {
-    return null
+  if (!browserSupportsSpeechRecognition) {
+    return <span>No browser support</span>
   }
 
   return (

--- a/example/src/Dictaphones.js
+++ b/example/src/Dictaphones.js
@@ -16,10 +16,6 @@ export default () => {
   })
   const listenOnce = () => SpeechRecognition.startListening({ continuous: false })
 
-  if (!SpeechRecognition.browserSupportsSpeechRecognition()) {
-    return null
-  }
-
   return (
     <div>
       {showFirstWidget && <DictaphoneWidgetA />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -94,10 +94,11 @@ export default class RecognitionManager {
     this.pauseAfterDisconnect = false
   }
 
-  updateTranscript({ results, resultIndex = 0 }) {
+  updateTranscript({ results, resultIndex }) {
+    const currentIndex = resultIndex === undefined ? results.length - 1 : resultIndex
     this.interimTranscript = ''
     this.finalTranscript = ''
-    for (let i = resultIndex; i < results.length; ++i) {
+    for (let i = currentIndex; i < results.length; ++i) {
       if (results[i].isFinal && (!isAndroid() || results[i][0].confidence > 0)) {
         this.updateFinalTranscript(results[i][0].transcript)
       } else {

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -12,6 +12,7 @@ export default class RecognitionManager {
     this.listening = false
     this.subscribers = {}
     this.onStopListening = () => {}
+    this.previousResultWasFinalOnly = false
 
     if (this.recognition) {
       this.recognition.continuous = false
@@ -108,7 +109,18 @@ export default class RecognitionManager {
         )
       }
     }
-    this.emitTranscriptChange(this.interimTranscript, this.finalTranscript)
+    let isDuplicateResult = false
+    if (this.interimTranscript === '') {
+      if (this.previousResultWasFinalOnly) {
+        isDuplicateResult = true
+      }
+      this.previousResultWasFinalOnly = true
+    } else {
+      this.previousResultWasFinalOnly = false
+    }
+    if (!isDuplicateResult) {
+      this.emitTranscriptChange(this.interimTranscript, this.finalTranscript)
+    }
   }
 
   updateFinalTranscript(newFinalTranscript) {

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -2,7 +2,7 @@ import isAndroid from './isAndroid'
 import { debounce, concatTranscripts } from './utils'
 
 export default class RecognitionManager {
-  constructor(SpeechRecognitionClient) {
+  constructor(SpeechRecognition) {
     this.recognition = null
     this.pauseAfterDisconnect = false
     this.interimTranscript = ''
@@ -16,18 +16,18 @@ export default class RecognitionManager {
     this.startListening = this.startListening.bind(this)
     this.stopListening = this.stopListening.bind(this)
     this.abortListening = this.abortListening.bind(this)
-    this.setSpeechRecognitionClient = this.setSpeechRecognitionClient.bind(this)
+    this.setSpeechRecognition = this.setSpeechRecognition.bind(this)
 
-    this.setSpeechRecognitionClient(SpeechRecognitionClient)
+    this.setSpeechRecognition(SpeechRecognition)
 
     if (isAndroid()) {
       this.updateFinalTranscript = debounce(this.updateFinalTranscript, 250, true)
     }
   }
 
-  setSpeechRecognitionClient(SpeechRecognitionClient) {
-    if (SpeechRecognitionClient) {
-      this.recognition = new SpeechRecognitionClient()
+  setSpeechRecognition(SpeechRecognition) {
+    if (SpeechRecognition) {
+      this.recognition = new SpeechRecognition()
       this.recognition.continuous = false
       this.recognition.interimResults = true
       this.recognition.onresult = this.updateTranscript.bind(this)

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -122,7 +122,7 @@ export default class RecognitionManager {
       }
     }
     let isDuplicateResult = false
-    if (this.interimTranscript === '') {
+    if (this.interimTranscript === '' && this.finalTranscript !== '') {
       if (this.previousResultWasFinalOnly) {
         isDuplicateResult = true
       }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -168,7 +168,7 @@ const SpeechRecognition = {
   },
   getRecognitionManager: () => {
     if (!recognitionManager) {
-      recognitionManager = new RecognitionManager()
+      recognitionManager = new RecognitionManager(DefaultSpeechRecognitionClient)
     }
     return recognitionManager
   },

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -144,9 +144,21 @@ const useSpeechRecognition = ({
   }
 }
 
+const DefaultSpeechRecognitionClient =
+  typeof window !== 'undefined' &&
+  (window.SpeechRecognition ||
+    window.webkitSpeechRecognition ||
+    window.mozSpeechRecognition ||
+    window.msSpeechRecognition ||
+    window.oSpeechRecognition)
+let browserSupportsSpeechRecognition = !!DefaultSpeechRecognitionClient
 let recognitionManager
 const SpeechRecognition = {
   counter: 0,
+  setSpeechRecognitionClient: (SpeechRecognitionClient) => {
+    recognitionManager = new RecognitionManager(SpeechRecognitionClient)
+    browserSupportsSpeechRecognition = true
+  },
   getRecognitionManager: () => {
     if (!recognitionManager) {
       recognitionManager = new RecognitionManager()
@@ -169,10 +181,7 @@ const SpeechRecognition = {
     const recognitionManager = SpeechRecognition.getRecognitionManager()
     await recognitionManager.abortListening()
   },
-  browserSupportsSpeechRecognition: () => {
-    const recognitionManager = SpeechRecognition.getRecognitionManager()
-    return recognitionManager.browserSupportsSpeechRecognition
-  }
+  browserSupportsSpeechRecognition: () => browserSupportsSpeechRecognition
 }
 
 export { useSpeechRecognition }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -4,14 +4,14 @@ import { clearTrancript, appendTrancript } from './actions'
 import { transcriptReducer } from './reducers'
 import RecognitionManager from './RecognitionManager'
 
-const DefaultSpeechRecognitionClient =
+const DefaultSpeechRecognition =
   typeof window !== 'undefined' &&
   (window.SpeechRecognition ||
     window.webkitSpeechRecognition ||
     window.mozSpeechRecognition ||
     window.msSpeechRecognition ||
     window.oSpeechRecognition)
-let _browserSupportsSpeechRecognition = !!DefaultSpeechRecognitionClient
+let _browserSupportsSpeechRecognition = !!DefaultSpeechRecognition
 let recognitionManager
 
 const useSpeechRecognition = ({
@@ -158,17 +158,17 @@ const useSpeechRecognition = ({
 }
 const SpeechRecognition = {
   counter: 0,
-  setSpeechRecognitionClient: (SpeechRecognitionClient) => {
+  applyPolyfill: (PolyfillSpeechRecognition) => {
     if (recognitionManager) {
-      recognitionManager.setSpeechRecognitionClient(SpeechRecognitionClient)
+      recognitionManager.setSpeechRecognition(PolyfillSpeechRecognition)
     } else {
-      recognitionManager = new RecognitionManager(SpeechRecognitionClient)
+      recognitionManager = new RecognitionManager(PolyfillSpeechRecognition)
     }
     _browserSupportsSpeechRecognition = true
   },
   getRecognitionManager: () => {
     if (!recognitionManager) {
-      recognitionManager = new RecognitionManager(DefaultSpeechRecognitionClient)
+      recognitionManager = new RecognitionManager(DefaultSpeechRecognition)
     }
     return recognitionManager
   },

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import '../tests/vendor/corti'
+import { CortiSpeechRecognition } from '../tests/vendor/corti'
 import SpeechRecognition, { useSpeechRecognition } from './SpeechRecognition'
 import isAndroid from './isAndroid'
 import RecognitionManager from './RecognitionManager'
@@ -7,7 +7,7 @@ import RecognitionManager from './RecognitionManager'
 jest.mock('./isAndroid')
 
 const mockRecognitionManager = () => {
-  const recognitionManager = new RecognitionManager()
+  const recognitionManager = new RecognitionManager(window.SpeechRecognition)
   SpeechRecognition.getRecognitionManager = () => recognitionManager
   return recognitionManager
 }
@@ -17,18 +17,15 @@ describe('SpeechRecognition', () => {
     isAndroid.mockClear()
   })
 
-  test('indicates when SpeechRecognition API is available', () => {
-    const recognitionManager = mockRecognitionManager()
-    recognitionManager.browserSupportsSpeechRecognition = true
+  test('sets SpeechRecognitionClient correctly', () => {
+    const MockSpeechRecognition = class {}
+
+    expect(SpeechRecognition.getRecognition() instanceof CortiSpeechRecognition).toEqual(true)
+
+    SpeechRecognition.setSpeechRecognitionClient(MockSpeechRecognition)
 
     expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(true)
-  })
-
-  test('indicates when SpeechRecognition API is not available', () => {
-    const recognitionManager = mockRecognitionManager()
-    recognitionManager.browserSupportsSpeechRecognition = false
-
-    expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(false)
+    expect(SpeechRecognition.getRecognition() instanceof MockSpeechRecognition).toEqual(true)
   })
 
   test('sets default transcripts correctly', () => {

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -114,11 +114,14 @@ describe('SpeechRecognition', () => {
     expect(finalTranscript).toEqual('')
   })
 
-  test('ignores speech when listening is aborted', () => {
+  test('ignores speech when listening is aborted', async () => {
     mockRecognitionManager()
     const { result } = renderHook(() => useSpeechRecognition())
     const speech = 'This is a test'
 
+    await act(async () => {
+      await SpeechRecognition.startListening()
+    })
     act(() => {
       SpeechRecognition.abortListening()
     })

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -17,12 +17,12 @@ describe('SpeechRecognition', () => {
     isAndroid.mockClear()
   })
 
-  test('sets SpeechRecognitionClient correctly', () => {
+  test('sets applyPolyfill correctly', () => {
     const MockSpeechRecognition = class {}
 
     expect(SpeechRecognition.getRecognition() instanceof CortiSpeechRecognition).toEqual(true)
 
-    SpeechRecognition.setSpeechRecognitionClient(MockSpeechRecognition)
+    SpeechRecognition.applyPolyfill(MockSpeechRecognition)
 
     expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(true)
     expect(SpeechRecognition.getRecognition() instanceof MockSpeechRecognition).toEqual(true)

--- a/tests/vendor/corti.js
+++ b/tests/vendor/corti.js
@@ -196,13 +196,14 @@ const Corti = (_root) => {
       }
       _root.SpeechRecognition = newSpeechRecognition
     },
-
     unpatch: function() {
       _root.SpeechRecognition = _productionVersion
-    }
+    },
+    newSpeechRecognition
   }
 }
 
 const mockSpeechRecognition = Corti(global)
 mockSpeechRecognition.patch()
+export const CortiSpeechRecognition = mockSpeechRecognition.newSpeechRecognition
 export default mockSpeechRecognition


### PR DESCRIPTION
The first support for polyfill integration! Highly experimental stuff. Allows for the Speech Recognition engine to be switched out for a polyfill. Tested with an Azure polyfill with the integration documented.


# Polyfills

If you want `react-speech-recognition` to work on more browsers than just Chrome, you can integrate a polyfill. This is a piece of code that fills in some missing feature in browsers that don't support it.

Under the hood, Web Speech API in Chrome uses Google's speech recognition servers. To replicate this functionality elsewhere, you will need to host your own speech recognition service and implement the Web Speech API using that service. That implementation, which is essentially a polyfill, can then be plugged into `react-speech-recognition`. You can write that polyfill yourself, but it's recommended you use one someone else has already made.

# Basic usage

The `SpeechRecognition` class exported by `react-speech-recognition` has the method `applyPolyfill`. This can take an implementation of the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). From then on, that implementation will used by `react-speech-recognition` to transcribe speech picked up by the microphone.

```
SpeechRecognition.applyPolyfill(SpeechRecognitionPolyfill)
```

Note that this type of polyfill that does not pollute the global scope is known as a "ponyfill" - the distinction is explained [here](https://ponyfoo.com/articles/polyfills-or-ponyfills). `react-speech-recognition` will also pick up traditional polyfills - just make sure you import them before `react-speech-recognition`.

## Usage recommendations
* Call this as early as possible to minimise periods where fallback content, which you should render while the polyfill is loading, is rendered
* Use your own `loadingSpeechRecognition` state rather than `browserSupportsSpeechRecognition` to decide when to render fallback content when Speech Recognition is not available. This is because on Chrome, `browserSupportsSpeechRecognition` will return `true` - as a result, your speech recognition component will appear briefly with the Google Speech Recognition engine and then with the polyfill engine, potentially causing a janky user experience. Some example code using the loading state approach can be found below
* After `applyPolyfill` has been called, `browserSupportsSpeechRecognition` will always be `true`. The polyfill itself may not work on all browsers - it's worth having a further fallback to cover that case. Polyfills will usually require WebRTC support in the browser, so it's worth checking that `window.navigator.mediaDevices.getUserMedia` is present
* Do not rely on polyfills being perfect implementations of the Speech Recognition specification - make sure you have tested them in different browsers and are aware of their individual limitations

# Polyfill libraries

Rather than roll your own, you should use a ready-made polyfill for one of the major cloud providers' speech recognition services.

## Azure Cognitive Services

This is Microsoft's offering for speech recognition (among many other features). The free trial gives you $200 of credit to get started. It's pretty easy to set up - see the [documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/).

* Polyfill repo: [web-speech-cognitive-services](https://github.com/compulim/web-speech-cognitive-services)
* Polyfill author: [compulim](https://github.com/compulim)
* Requirements:
  * Install `web-speech-cognitive-services` and `microsoft-cognitiveservices-speech-sdk` in your web app for this polyfill to function
  * You will need two things to configure this polyfill: the name of the Azure region your Speech Service is deployed in, plus a subscription key (or better still, an authorization token). [This doc](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/overview#find-keys-and-region) explains how to find those

Here is a basic example combining `web-speech-cognitive-services` and `react-speech-recognition` to get you started. This code worked with version 7.1.0 of the polyfill in February 2021 - if it has become outdated due to changes in the polyfill or in Azure Cognitive Services, please raise a GitHub issue or PR to get this updated.

```
import React, { useEffect, useState } from 'react';
import createSpeechServicesPonyfill from 'web-speech-cognitive-services';
import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';

const SUBSCRIPTION_KEY = '<INSERT_SUBSCRIPTION_KEY_HERE>';
const REGION = '<INSERT_REGION_HERE>';
const TOKEN_ENDPOINT = `https://${REGION}.api.cognitive.microsoft.com/sts/v1.0/issuetoken`;

const Dictaphone = () => {
  const [loadingSpeechRecognition, setLoadingSpeechRecognition] = useState(true);
  const { transcript, resetTranscript } = useSpeechRecognition();

  const startListening = () => SpeechRecognition.startListening({
    continuous: true,
    language: 'en-US'
  });

  useEffect(() => {
    const loadSpeechRecognition = async () => {
      const response = await fetch(TOKEN_ENDPOINT, {
        method: 'POST',
        headers: { 'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY }
      });
      const authorizationToken = await response.text();
      const {
        SpeechRecognition: AzureSpeechRecognition
      } = await createSpeechServicesPonyfill({
        credentials: {
          region: REGION,
          authorizationToken,
        }
      });
      SpeechRecognition.applyPolyfill(AzureSpeechRecognition);
      setLoadingSpeechRecognition(false);
    }
    loadSpeechRecognition();
  }, []);

  if (loadingSpeechRecognition) {
    return null;
  }

  return (
    <div>
      <button onClick={startListening}>Start</button>
      <button onClick={SpeechRecognition.stopListening}>Stop</button>
      <button onClick={resetTranscript}>Reset</button>
      <p>{transcript}</p>
    </div>
  );
};
export default Dictaphone;
```

### Caveats
* On Safari and Firefox, an error will be thrown if calling `startListening` to switch to a different language without first calling `stopListening`. It's recommended that you stick to one language and, if you do need to change languages, call `stopListening` first
* If you don't specify a language, Azure will return a 400 response. When calling `startListening`, you will need to explicitly provide one of the language codes defined [here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). For English, use `en-GB` or `en-US`
* Safari will throw an error on `localhost` as it requires HTTPS. [ngrok](https://ngrok.com/) is a nice tool for serving a local web app over HTTPS (also good for testing your web app on mobile devices as well)
* Currently untested on iOS (let me know if it works!)

## AWS Transcribe

There is no polyfill for [AWS Transcribe](https://aws.amazon.com/transcribe/) in the ecosystem yet, though a promising project can be found [here](https://github.com/ceuk/speech-recognition-aws-polyfill).

# Providing your own polyfill

If you want to roll your own implementation of the Speech Recognition API, follow the [W3C SpeechRecognition specification](https://wicg.github.io/speech-api/#speechreco-section). You should implement at least the following for `react-speech-recognition` to work:
* `continuous` (property)
* `lang` (property)
* `interimResults` (property)
* `onresult` (property). On the events received, the following properties are used:
  * `event.resultIndex`
  * `event.results[i].isFinal`
  * `event.results[i][0].transcript`
  * `event.results[i][0].confidence`
* `onend` (property)
* `start` (method)
* `stop` (method)
* `abort` (method)

