### PR TITLE
Microphone availability detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ Without a polyfill, the Web Speech API is largely only supported by Google brows
 
 For all other browsers, you can render fallback content using the `SpeechRecognition.browserSupportsSpeechRecognition` function described above. Alternatively, as mentioned before, you can integrate a [polyfill](docs/POLYFILLS.md).
 
+## Detecting when the user denies access to the microphone
+
+Even if the browser supports the Web Speech API, the user still has to give permission for their microphone to be used before transcription can begin. They are asked for permission when `react-speech-recognition` first tries to start listening. At this point, you can detect when the user denies access via the `isMicrophoneAvailable` state. When this becomes `false`, it's advised that you disable voice-driven features and indicate that microphone access is needed for them to work.
+
+```
+if (!isMicrophoneAvailable) {
+  // Render some fallback content
+}
+```
+
 ## Controlling the microphone
 
 Before consuming the transcript, you should be familiar with `SpeechRecognition`, which gives you control over the microphone. The state of the microphone is global, so any functions you call on this object will affect _all_ components using `useSpeechRecognition`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,7 @@ These are returned from `useSpeechRecognition`:
     resetTranscript,
     listening,
     browserSupportsSpeechRecognition,
+    isMicrophoneAvailable,
   } = useSpeechRecognition()
 ```
 
@@ -98,6 +99,16 @@ if (browserSupportsContinuousListening) {
   SpeechRecognition.startListening({ continuous: true })
 } else {
   // Fallback behaviour
+}
+```
+
+#### isMicrophoneAvailable [bool]
+
+The user has to give permission for their microphone to be used before transcription can begin. They are asked for permission when `react-speech-recognition` first tries to start listening. This state will become `false` if they deny access. In this case, it's advised that you disable voice-driven features and indicate that microphone access is needed for them to work.
+
+```
+if (!isMicrophoneAvailable) {
+  // Render some fallback content
 }
 ```
 

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -184,6 +184,7 @@ If you want to roll your own implementation of the Speech Recognition API, follo
   * `event.results[i][0].transcript`
   * `event.results[i][0].confidence`
 * `onend` (property)
+* `onerror` (property)
 * `start` (method)
 * `stop` (method)
 * `abort` (method)

--- a/example/src/Dictaphone/Dictaphone.js
+++ b/example/src/Dictaphone/Dictaphone.js
@@ -12,7 +12,8 @@ const Dictaphone = ({ commands }) => {
     finalTranscript,
     resetTranscript,
     listening,
-    browserSupportsSpeechRecognition
+    browserSupportsSpeechRecognition,
+    isMicrophoneAvailable,
   } = useSpeechRecognition({ transcribing, clearTranscriptOnListen, commands })
   useEffect(() => {
     if (interimTranscript !== '') {
@@ -25,6 +26,10 @@ const Dictaphone = ({ commands }) => {
 
   if (!browserSupportsSpeechRecognition) {
     return <span>No browser support</span>
+  }
+
+  if (!isMicrophoneAvailable) {
+    return <span>Please allow access to the microphone</span>
   }
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "scripts": {

--- a/src/RecognitionManager.js
+++ b/src/RecognitionManager.js
@@ -193,7 +193,6 @@ export default class RecognitionManager {
         // DOMExceptions indicate a redundant microphone start - safe to swallow
         if (!(e instanceof DOMException)) {
           this.emitMicrophoneAvailabilityChange(false)
-          await this.abortListening()
         }
       }
     }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -30,6 +30,8 @@ const useSpeechRecognition = ({
     finalTranscript: ''
   })
   const [listening, setListening] = useState(recognitionManager.listening)
+  const [isMicrophoneAvailable, setMicrophoneAvailable] =
+    useState(recognitionManager.isMicrophoneAvailable)
   const commandsRef = useRef(commands)
   commandsRef.current = commands
 
@@ -133,6 +135,7 @@ const useSpeechRecognition = ({
     SpeechRecognition.counter += 1
     const callbacks = {
       onListeningChange: setListening,
+      onMicrophoneAvailabilityChange: setMicrophoneAvailable,
       onTranscriptChange: handleTranscriptChange,
       onClearTranscript: handleClearTranscript,
       onBrowserSupportsSpeechRecognitionChange: setBrowserSupportsSpeechRecognition,
@@ -157,6 +160,7 @@ const useSpeechRecognition = ({
     interimTranscript,
     finalTranscript,
     listening,
+    isMicrophoneAvailable,
     resetTranscript,
     browserSupportsSpeechRecognition,
     browserSupportsContinuousListening

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -1124,7 +1124,7 @@ describe('SpeechRecognition', () => {
     expect(mockCommandCallback).toBeCalledWith('I would like a pizza', 'I would like a pizza', 1, { command, resetTranscript })
   })
 
-  test('sets isMicrophoneAvailable to false when unable to start listening', async () => {
+  test('sets isMicrophoneAvailable to false when recognition.start() throws', async () => {
     mockMicrophoneUnavailable()
     const { result } = renderHook(() => useSpeechRecognition())
 
@@ -1132,6 +1132,21 @@ describe('SpeechRecognition', () => {
 
     await act(async () => {
       await SpeechRecognition.startListening()
+    })
+
+    expect(result.current.isMicrophoneAvailable).toEqual(false)
+  })
+
+  test('sets isMicrophoneAvailable to false when not-allowed error emitted', async () => {
+    mockRecognitionManager()
+    const { result } = renderHook(() => useSpeechRecognition())
+
+    expect(result.current.isMicrophoneAvailable).toEqual(true)
+
+    await act(async () => {
+      await SpeechRecognition.getRecognitionManager().recognition.onerror({
+        error: 'not-allowed'
+      })
     })
 
     expect(result.current.isMicrophoneAvailable).toEqual(false)

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -19,6 +19,17 @@ const mockRecognitionManager = () => {
   return recognitionManager
 }
 
+const mockMicrophoneUnavailable = () => {
+  const mockSpeechRecognition =
+    jest.createMockFromModule('../tests/vendor/corti').CortiSpeechRecognition
+  mockSpeechRecognition.mockImplementation(() => ({
+    start: async () => Promise.reject(new Error())
+  }))
+  SpeechRecognition.applyPolyfill(mockSpeechRecognition)
+  const recognitionManager = new RecognitionManager(mockSpeechRecognition)
+  SpeechRecognition.getRecognitionManager = () => recognitionManager
+}
+
 describe('SpeechRecognition', () => {
   beforeEach(() => {
     isAndroid.mockClear()
@@ -1111,5 +1122,18 @@ describe('SpeechRecognition', () => {
 
     expect(mockCommandCallback.mock.calls.length).toBe(1)
     expect(mockCommandCallback).toBeCalledWith('I would like a pizza', 'I would like a pizza', 1, { command, resetTranscript })
+  })
+
+  test('sets isMicrophoneAvailable to false when unable to start listening', async () => {
+    mockMicrophoneUnavailable()
+    const { result } = renderHook(() => useSpeechRecognition())
+
+    expect(result.current.isMicrophoneAvailable).toEqual(true)
+
+    await act(async () => {
+      await SpeechRecognition.startListening()
+    })
+
+    expect(result.current.isMicrophoneAvailable).toEqual(false)
   })
 })


### PR DESCRIPTION
When `react-speech-recognition` first starts to listen, the browser will usually ask the user whether they give permission for the microphone to be used. If they deny access, `react-speech-recognition` did not previously handle this well:
* For native browser implementations of the Web Speech API, it would be unaware that permission hadn't been given and indicate to consumers that the microphone was listening
* For polyfills that throw errors when attempting to start listening in such a case, the error was not being caught, resulting in consumer apps crashing

This PR introduces a new state: `isMicrophoneAvailable`. If the user denies access to the microphone, the value of this will change to `false`. This applies in both of the following cases:
* On-spec case: where the recognition object passes an error object with value `{ error: 'not-allowed' }` to its `onerror` callback
* Off-spec case: for polyfills that don't implement `onerror` but instead just throw an error from their `start` method

After this PR, consumers can use this library with greater confidence that their apps will continue to function even when the user denies microphone access, and have the ability to render fallback content in such a case.