### PR TITLE
removePolyfill function

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -272,3 +272,11 @@ Replace the native Speech Recognition engine (if there is one) with a custom imp
 ```
 SpeechRecognition.applyPolyfill(SpeechRecognitionPolyfill)
 ```
+
+#### removePolyfill
+
+If a polyfill was applied using `applyPolyfill`, reset the Speech Recognition engine to the native implementation. This can be useful when the user switches to a language that is supported by the native engine but not the polyfill engine.
+
+```
+SpeechRecognition.removePolyfill()
+```

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -14,6 +14,12 @@ SpeechRecognition.applyPolyfill(SpeechRecognitionPolyfill)
 
 Note that this type of polyfill that does not pollute the global scope is known as a "ponyfill" - the distinction is explained [here](https://ponyfoo.com/articles/polyfills-or-ponyfills). `react-speech-recognition` will also pick up traditional polyfills - just make sure you import them before `react-speech-recognition`.
 
+Polyfills can be removed using `removePolyfill`. This can be useful when the user switches to a language that is supported by the native Speech Recognition engine but not the polyfill engine.
+
+```
+SpeechRecognition.removePolyfill()
+```
+
 ## Usage recommendations
 * Call this as early as possible to minimise periods where fallback content, which you should render while the polyfill is loading, is rendered. Also note that if there is a Speech Recognition implementation already listening to the microphone, this will be turned off when the polyfill is applied, so make sure the polyfill is applied before rendering any buttons to start listening
 * After `applyPolyfill` has been called, `browserSupportsSpeechRecognition` will be `true` on _most_ browsers, but there are still exceptions. Browsers like Internet Explorer do not support the APIs needed for polyfills - in these cases where `browserSupportsSpeechRecognition` is `false`, you should still have some suitable fallback content

--- a/example/src/Dictaphones.js
+++ b/example/src/Dictaphones.js
@@ -25,6 +25,7 @@ export default () => {
       <button onClick={listenContinuouslyInChinese}>Listen continuously (Chinese)</button>
       <button onClick={toggleShowFirstWidget}>Toggle first widget</button>
       <button onClick={SpeechRecognition.stopListening}>Stop</button>
+      <button onClick={SpeechRecognition.removePolyfill}>Remove polyfill</button>
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "💬Speech recognition for your React app",
   "main": "lib/index.js",
   "homepage": "https://webspeechrecognition.com/",

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -178,6 +178,15 @@ const SpeechRecognition = {
     _browserSupportsSpeechRecognition = browserSupportsPolyfill
     _browserSupportsContinuousListening = browserSupportsPolyfill
   },
+  removePolyfill: () => {
+    if (recognitionManager) {
+      recognitionManager.setSpeechRecognition(NativeSpeechRecognition)
+    } else {
+      recognitionManager = new RecognitionManager(NativeSpeechRecognition)
+    }
+    _browserSupportsSpeechRecognition = !!NativeSpeechRecognition
+    _browserSupportsContinuousListening = _browserSupportsSpeechRecognition && !isAndroid()
+  },
   getRecognitionManager: () => {
     if (!recognitionManager) {
       recognitionManager = new RecognitionManager(NativeSpeechRecognition)

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -106,6 +106,25 @@ describe('SpeechRecognition', () => {
     expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(false)
   })
 
+  test('reverts to native recognition when removePolyfill called', () => {
+    const MockSpeechRecognition = class {}
+    SpeechRecognition.applyPolyfill(MockSpeechRecognition)
+
+    expect(SpeechRecognition.getRecognition() instanceof MockSpeechRecognition).toEqual(true)
+
+    browserSupportsPolyfills.mockImplementation(() => false)
+    SpeechRecognition.applyPolyfill()
+
+    expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(false)
+    expect(SpeechRecognition.browserSupportsContinuousListening()).toEqual(false)
+
+    SpeechRecognition.removePolyfill()
+
+    expect(SpeechRecognition.browserSupportsSpeechRecognition()).toEqual(true)
+    expect(SpeechRecognition.browserSupportsContinuousListening()).toEqual(true)
+    expect(SpeechRecognition.getRecognition() instanceof CortiSpeechRecognition).toEqual(true)
+  })
+
   test('sets browserSupportsContinuousListening to false when given falsey SpeechRecognition', () => {
     SpeechRecognition.applyPolyfill()
 


### PR DESCRIPTION
#### removePolyfill

If a polyfill was applied using `applyPolyfill`, reset the Speech Recognition engine to the native implementation. This can be useful when the user switches to a language that is supported by the native engine but not the polyfill engine.

```
SpeechRecognition.removePolyfill()
```

Inspired by https://github.com/JamesBrill/react-speech-recognition/issues/145