### PR TITLE
Add error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ if (!isMicrophoneAvailable) {
 }
 ```
 
+## Detecting errors during speech recognition
+  
+Some browsers that do support `SpeechRecognition` API and have access to microphone still fail to function correctly. See [issue with brave for example](https://github.com/brave/brave-browser/issues/3725#issuecomment-555694620). In this case you can detect the error via `error` state. Initially it has `null` value, when `SpeechRecognition` error event is emitted it will receive its value.
+
 ## Controlling the microphone
 
 Before consuming the transcript, you should be familiar with `SpeechRecognition`, which gives you control over the microphone. The state of the microphone is global, so any functions you call on this object will affect _all_ components using `useSpeechRecognition`.

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -32,6 +32,7 @@ const useSpeechRecognition = ({
   const [listening, setListening] = useState(recognitionManager.listening)
   const [isMicrophoneAvailable, setMicrophoneAvailable] =
     useState(recognitionManager.isMicrophoneAvailable)
+  const [error, setError] = useState(recognitionManager.error)
   const commandsRef = useRef(commands)
   commandsRef.current = commands
 
@@ -136,6 +137,7 @@ const useSpeechRecognition = ({
     const callbacks = {
       onListeningChange: setListening,
       onMicrophoneAvailabilityChange: setMicrophoneAvailable,
+      onError: setError,
       onTranscriptChange: handleTranscriptChange,
       onClearTranscript: handleClearTranscript,
       onBrowserSupportsSpeechRecognitionChange: setBrowserSupportsSpeechRecognition,
@@ -161,6 +163,7 @@ const useSpeechRecognition = ({
     finalTranscript,
     listening,
     isMicrophoneAvailable,
+    error,
     resetTranscript,
     browserSupportsSpeechRecognition,
     browserSupportsContinuousListening

--- a/src/SpeechRecognition.test.js
+++ b/src/SpeechRecognition.test.js
@@ -1170,4 +1170,32 @@ describe('SpeechRecognition', () => {
 
     expect(result.current.isMicrophoneAvailable).toEqual(false)
   })
+
+  test('sets error value when recognition.start() throws', async () => {
+    mockMicrophoneUnavailable()
+    const { result } = renderHook(() => useSpeechRecognition())
+
+    expect(result.current.error).toEqual(null)
+
+    await act(async () => {
+      await SpeechRecognition.startListening()
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  test('sets error with error value when not-allowed error emitted', async () => {
+    mockRecognitionManager()
+    const { result } = renderHook(() => useSpeechRecognition())
+
+    expect(result.current.error).toEqual(null)
+
+    await act(async () => {
+      await SpeechRecognition.getRecognitionManager().recognition.onerror({
+        error: 'not-allowed'
+      })
+    })
+
+    expect(result.current.error).toHaveProperty('error', 'not-allowed')
+  })
 })


### PR DESCRIPTION
I would find it useful to have access to an error state. Not sure what others experience is like but currently the native `SpeechRecognition` API is functional only in chrome. Edge, Brave and Firefox (after enabling the flag) all throw different errors. In this case both `browserSupportsSpeechRecognition` and `isMicrophoneAvailable` are `true` but nothing is actually recognised and currently there is no way to access or even recognise that some error has been emitted. 

I can add examples and another PR for typings after some feedback on this PR.