### PR TITLE
Update langauge value of Korean

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -202,7 +202,7 @@ Some known supported languages (based on [this Stack Overflow post](http://stack
 * Italian `it-IT`
 * Indonesian `id`
 * Japanese `ja`
-* Korean `ko`
+* Korean `ko-KR`
 * Latin `la`
 * Mandarin Chinese `zh-CN`
 * Taiwanese `zh-TW`


### PR DESCRIPTION
Hello, I am using your library well.

To use the Korean speech recognition feature, I set the parameter `language` of `startListening()` to `ko` as guided in the [API documentation](https://github.com/JamesBrill/react-speech-recognition/blob/master/docs/API.md#language-string).

Before November 12, 2024, speech recognition results were properly displayed in Korean.
However, on November 14, when using Android browsers and Android apps, the results were displayed in English even when speaking in Korean.

On desktop Chrome and iOS browsers and apps, Korean results are displayed correctly.
It is unclear whether this issue in the Android is related to [Chrome 131 release (November 12, 2024)](https://developer.chrome.com/release-notes/131), but it is certain that `language: 'ko'` does not work properly in Android.

Upon checking an attribute `lang` of `SpeechRecognition` in [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/lang), it is recommended to use the **BCP 47 language tag**.
After changing `language: 'ko'` to `language: 'ko-KR'`, Korean speech recognition worked well across all OS environments.

So I would appreciate it if you could update the language value in the [API documentation](https://github.com/JamesBrill/react-speech-recognition/blob/master/docs/API.md#language-string).