### PR TITLE
docs: remove Speechly instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ By default, speech recognition is not supported in all browsers, with the best n
 `react-speech-recognition` currently supports polyfills for the following cloud providers:
 
 <div>
-  <a href="https://www.speechly.com/?utm_source=github">
-    <img src="docs/logos/speechly.png" width="200" alt="Speechly">
-  </a>
-  <img width="50"></img>
   <a href="https://azure.microsoft.com/en-gb/services/cognitive-services/speech-to-text/">
     <img src="docs/logos/microsoft.png" width="175" alt="Microsoft Azure Cognitive Services">
   </a>
@@ -103,40 +99,47 @@ By default, speech recognition is not supported in all browsers, with the best n
 
 ## Cross-browser example
 
-You can find the full guide for setting up a polyfill [here](docs/POLYFILLS.md). Alternatively, here is a quick (and free) example using Speechly:
-* Install `@speechly/speech-recognition-polyfill` in your web app
-* You will need a Speechly app ID. To get one of these, sign up for free with Speechly and follow [the guide here](https://docs.speechly.com/quick-start/stt-only/)
+You can find the full guide for setting up a polyfill [here](docs/POLYFILLS.md). Alternatively, here is a quick example using Azure:
+* Install `web-speech-cognitive-services` and `microsoft-cognitiveservices-speech-sdk` in your web app.
+* You will need two things to configure this polyfill: the name of the Azure region your Speech Service is deployed in, plus a subscription key (or better still, an authorization token). [This doc](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/overview#find-keys-and-region) explains how to find those
 * Here's a component for a push-to-talk button. The basic example above would also work fine.
 ```jsx
 import React from 'react';
-import { createSpeechlySpeechRecognition } from '@speechly/speech-recognition-polyfill';
+import createSpeechServicesPonyfill from 'web-speech-cognitive-services';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
-const appId = '<INSERT_SPEECHLY_APP_ID_HERE>';
-const SpeechlySpeechRecognition = createSpeechlySpeechRecognition(appId);
-SpeechRecognition.applyPolyfill(SpeechlySpeechRecognition);
+const SUBSCRIPTION_KEY = '<INSERT_SUBSCRIPTION_KEY_HERE>';
+const REGION = '<INSERT_REGION_HERE>';
+
+const { SpeechRecognition: AzureSpeechRecognition } = createSpeechServicesPonyfill({
+  credentials: {
+    region: REGION,
+    subscriptionKey: SUBSCRIPTION_KEY,
+  }
+});
+SpeechRecognition.applyPolyfill(AzureSpeechRecognition);
 
 const Dictaphone = () => {
   const {
     transcript,
-    listening,
+    resetTranscript,
     browserSupportsSpeechRecognition
   } = useSpeechRecognition();
-  const startListening = () => SpeechRecognition.startListening({ continuous: true });
+
+  const startListening = () => SpeechRecognition.startListening({
+    continuous: true,
+    language: 'en-US'
+  });
 
   if (!browserSupportsSpeechRecognition) {
-    return <span>Browser doesn't support speech recognition.</span>;
+    return null;
   }
 
   return (
     <div>
-      <p>Microphone: {listening ? 'on' : 'off'}</p>
-      <button
-        onTouchStart={startListening}
-        onMouseDown={startListening}
-        onTouchEnd={SpeechRecognition.stopListening}
-        onMouseUp={SpeechRecognition.stopListening}
-      >Hold to talk</button>
+      <button onClick={startListening}>Start</button>
+      <button onClick={SpeechRecognition.abortListening}>Abort</button>
+      <button onClick={resetTranscript}>Reset</button>
       <p>{transcript}</p>
     </div>
   );

--- a/docs/POLYFILLS.md
+++ b/docs/POLYFILLS.md
@@ -29,66 +29,6 @@ SpeechRecognition.removePolyfill()
 
 Rather than roll your own, you should use a ready-made polyfill for a cloud provider's speech recognition service. `react-speech-recognition` currently supports polyfills for the following cloud providers:
 
-## Speechly
-
-<a href="https://www.speechly.com/?utm_source=github">
-  <img src="logos/speechly.png" width="200" alt="Speechly">
-</a>
-
-[Speechly](https://www.speechly.com/) specialises in enabling developers to create voice-driven UIs and provides a speech recognition API with a generous free tier to get you started. Their web speech recognition polyfill was developed with `react-speech-recognition` in mind so is a great choice to combine with this library. You can see an example of the two libraries working together in its [README](https://github.com/speechly/speech-recognition-polyfill#integrating-with-react-speech-recognition).
-
-* Polyfill repo: [speech-recognition-polyfill](https://github.com/speechly/speech-recognition-polyfill)
-* Polyfill author: [speechly](https://github.com/speechly)
-* Requirements: 
-  * Install `@speechly/speech-recognition-polyfill` in your web app
-  * You will need a Speechly app ID. To get one of these, sign up with Speechly and follow [the guide here](https://docs.speechly.com/quick-start/stt-only/)
-
-Here is a basic example combining `speech-recognition-polyfill` and `react-speech-recognition` to get you started. This code worked with version 1.0.0 of the polyfill in May 2021 - if it has become outdated due to changes in the polyfill or in Speechly, please raise a GitHub issue or PR to get this updated.
-
-```jsx
-import React from 'react';
-import { createSpeechlySpeechRecognition } from '@speechly/speech-recognition-polyfill';
-import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
-
-const appId = '<INSERT_SPEECHLY_APP_ID_HERE>';
-const SpeechlySpeechRecognition = createSpeechlySpeechRecognition(appId);
-SpeechRecognition.applyPolyfill(SpeechlySpeechRecognition);
-
-const Dictaphone = () => {
-  const {
-    transcript,
-    listening,
-    browserSupportsSpeechRecognition
-  } = useSpeechRecognition();
-  const startListening = () => SpeechRecognition.startListening({ continuous: true });
-
-  if (!browserSupportsSpeechRecognition) {
-    return <span>Browser doesn't support speech recognition.</span>;
-  }
-
-  return (
-    <div>
-      <p>Microphone: {listening ? 'on' : 'off'}</p>
-      <button
-        onTouchStart={startListening}
-        onMouseDown={startListening}
-        onTouchEnd={SpeechRecognition.stopListening}
-        onMouseUp={SpeechRecognition.stopListening}
-      >Hold to talk</button>
-      <p>{transcript}</p>
-    </div>
-  );
-};
-export default Dictaphone;
-```
-
-### Limitations
-* The `lang` property is currently unsupported, defaulting to English transcription. In `react-speech-recognition`, this means that the `language` property in `startListening` cannot be used to change languages when using this polyfill. New languages will be coming soon!
-* Transcripts are generated in uppercase letters without punctuation. If needed, you can transform them using [toLowerCase()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase)
-
-<br />
-<br />
-
 ## Microsoft Azure Cognitive Services
 
 <a href="https://azure.microsoft.com/en-gb/services/cognitive-services/speech-to-text/">


### PR DESCRIPTION
Removes setup instructions for Speechly; speechly.com is defunct and the polyfill has been archived.

Closes #191
Closes #182
Closes #160
Closes #150 
Closes #143 